### PR TITLE
Topic views + more

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -4,6 +4,41 @@
         "title": "Topic Fields",
         "fields": [
             {
+                "key": "field_5b9ace1a451fb",
+                "label": "Display Settings",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5b85b5c65fe52",
+                "label": "Show FAQ Answers",
+                "name": "faq-topic-show-answers",
+                "type": "true_false",
+                "instructions": "If checked the FAQ answer will be visible on page load.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
                 "key": "field_5b8598c5aeaa9",
                 "label": "FAQ Topic Image",
                 "name": "faq-topic-image",
@@ -26,47 +61,6 @@
                 "max_height": 500,
                 "max_size": "",
                 "mime_types": "jpg, png"
-            },
-            {
-                "key": "field_5b85b5c65fe52",
-                "label": "FAQ Show Answers",
-                "name": "faq-topic-show-answers",
-                "type": "true_false",
-                "instructions": "If checked the FAQ answer will be visible on page load.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "default_value": 0,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
-            },
-            {
-                "key": "field_5b90050373b29",
-                "label": "FAQ Topic Spotlight",
-                "name": "faq-topic-spotlight",
-                "type": "post_object",
-                "instructions": "Select a Spotlight to be displayed on the topic list page.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "post_type": [
-                    "ucf_spotlight"
-                ],
-                "taxonomy": [],
-                "allow_null": 0,
-                "multiple": 0,
-                "return_format": "object",
-                "ui": 1
             },
             {
                 "key": "field_5b9028cb19703",
@@ -124,6 +118,106 @@
                 "prepend": "",
                 "append": "",
                 "maxlength": ""
+            },
+            {
+                "key": "field_5b9acdc1451f9",
+                "label": "Frontend Topic Contents",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5b9ace2d451fc",
+                "label": "Single Topic View",
+                "name": "faq-topic-view-type",
+                "type": "select",
+                "instructions": "Select how this Topic's template should be displayed on the frontend.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "default": "Default",
+                    "custom": "Custom Content"
+                },
+                "default_value": [
+                    "default"
+                ],
+                "allow_null": 0,
+                "multiple": 0,
+                "ui": 0,
+                "ajax": 0,
+                "return_format": "value",
+                "placeholder": ""
+            },
+            {
+                "key": "field_5b90050373b29",
+                "label": "Topic Spotlight",
+                "name": "faq-topic-spotlight",
+                "type": "post_object",
+                "instructions": "Select a Spotlight to be displayed on the topic list page.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5b9ace2d451fc",
+                            "operator": "==",
+                            "value": "default"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "ucf_spotlight"
+                ],
+                "taxonomy": [],
+                "allow_null": 0,
+                "multiple": 0,
+                "return_format": "object",
+                "ui": 1
+            },
+            {
+                "key": "field_5b9ad0b9451fd",
+                "label": "Topic Custom Content",
+                "name": "faq-topic-custom-content",
+                "type": "wysiwyg",
+                "instructions": "Custom content to use on the single Topic view, in lieu of the template provided by the UCF FAQ Plugin.  You will need to include FAQ lists yourself using the <code>[ucf-faq-list]<\/code> shortcode.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5b9ace2d451fc",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
             }
         ],
         "location": [

--- a/includes/ucf-faq-config.php
+++ b/includes/ucf-faq-config.php
@@ -6,8 +6,9 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 	class UCF_FAQ_Config {
 		public static $option_prefix = 'ucf_faq_',
 		$option_defaults = array(
-			'include_athena_classes' => true,
-			'disable_faq_archive' => false,
+			'include_athena_classes'  => true,
+			'disable_faq_archive'     => false,
+			'disable_frontend_topics' => false
 		);
 
 
@@ -21,6 +22,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			$defaults = self::$option_defaults; // don't use self::get_option_defaults() here (default options haven't been set yet)
 			add_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] );
 			add_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] );
+			add_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_frontend_topics'] );
 		}
 
 
@@ -33,6 +35,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 		public static function delete_options() {
 			delete_option( self::$option_prefix . 'include_athena_classes' );
 			delete_option( self::$option_prefix . 'disable_faq_archive' );
+			delete_option( self::$option_prefix . 'disable_frontend_topics' );
 		}
 
 
@@ -47,8 +50,9 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 
 			// Apply default values configurable within the options page:
 			$configurable_defaults = array(
-				'include_athena_classes' => get_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] ),
-				'disable_faq_archive' => get_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] ),
+				'include_athena_classes'  => get_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] ),
+				'disable_faq_archive'     => get_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] ),
+				'disable_frontend_topics' => get_option( self::$option_prefix . 'disable_frontend_topics', $defaults['disable_frontend_topics'] ),
 			);
 
 			// Force configurable options to override $defaults, even if they are empty:
@@ -69,6 +73,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				switch ( $key ) {
 					case 'include_athena_classes':
 					case 'disable_faq_archive':
+					case 'disable_frontend_topics':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
 					default:
 						break;
@@ -125,6 +130,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			// Register settings
 			register_setting( 'ucf_faq', self::$option_prefix . 'include_athena_classes' );
 			register_setting( 'ucf_faq', self::$option_prefix . 'disable_faq_archive' );
+			register_setting( 'ucf_faq', self::$option_prefix . 'disable_frontend_topics' );
 
 			// Register setting sections
 			add_settings_section(
@@ -157,6 +163,19 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				array(  // extra arguments to pass to the callback function
 					'label_for'   => self::$option_prefix . 'disable_faq_archive',
 					'description' => 'If checked the FAQ Archive will be disabled.',
+					'type'        => 'checkbox'
+				)
+			);
+
+			add_settings_field(
+				self::$option_prefix . 'disable_frontend_topics',
+				'Disable Frontend Topics',  // formatted field title
+				array( 'UCF_FAQ_Config', 'display_settings_field' ),  // display callback
+					'ucf_faq',  // settings page slug
+					'ucf_faq_section_general',  // option section slug
+				array(  // extra arguments to pass to the callback function
+					'label_for'   => self::$option_prefix . 'disable_frontend_topics',
+					'description' => 'If checked, frontend Topic views will be disabled.  You should uncheck this box if you plan on using Pages with shortcodes to display Topics and FAQs instead of this plugin\'s included Topic views.',
 					'type'        => 'checkbox'
 				)
 			);

--- a/includes/ucf-faq-config.php
+++ b/includes/ucf-faq-config.php
@@ -7,8 +7,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 		public static $option_prefix = 'ucf_faq_',
 		$option_defaults = array(
 			'include_athena_classes'  => true,
-			'disable_faq_archive'     => false,
-			'disable_frontend_topics' => false
+			'disable_faq_archive'     => false
 		);
 
 
@@ -22,7 +21,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			$defaults = self::$option_defaults; // don't use self::get_option_defaults() here (default options haven't been set yet)
 			add_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] );
 			add_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] );
-			add_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_frontend_topics'] );
 		}
 
 
@@ -35,7 +33,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 		public static function delete_options() {
 			delete_option( self::$option_prefix . 'include_athena_classes' );
 			delete_option( self::$option_prefix . 'disable_faq_archive' );
-			delete_option( self::$option_prefix . 'disable_frontend_topics' );
 		}
 
 
@@ -52,7 +49,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			$configurable_defaults = array(
 				'include_athena_classes'  => get_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] ),
 				'disable_faq_archive'     => get_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] ),
-				'disable_frontend_topics' => get_option( self::$option_prefix . 'disable_frontend_topics', $defaults['disable_frontend_topics'] ),
 			);
 
 			// Force configurable options to override $defaults, even if they are empty:
@@ -73,7 +69,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				switch ( $key ) {
 					case 'include_athena_classes':
 					case 'disable_faq_archive':
-					case 'disable_frontend_topics':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
 					default:
 						break;
@@ -130,7 +125,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			// Register settings
 			register_setting( 'ucf_faq', self::$option_prefix . 'include_athena_classes' );
 			register_setting( 'ucf_faq', self::$option_prefix . 'disable_faq_archive' );
-			register_setting( 'ucf_faq', self::$option_prefix . 'disable_frontend_topics' );
 
 			// Register setting sections
 			add_settings_section(
@@ -163,19 +157,6 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				array(  // extra arguments to pass to the callback function
 					'label_for'   => self::$option_prefix . 'disable_faq_archive',
 					'description' => 'If checked the FAQ Archive will be disabled.',
-					'type'        => 'checkbox'
-				)
-			);
-
-			add_settings_field(
-				self::$option_prefix . 'disable_frontend_topics',
-				'Disable Frontend Topics',  // formatted field title
-				array( 'UCF_FAQ_Config', 'display_settings_field' ),  // display callback
-					'ucf_faq',  // settings page slug
-					'ucf_faq_section_general',  // option section slug
-				array(  // extra arguments to pass to the callback function
-					'label_for'   => self::$option_prefix . 'disable_frontend_topics',
-					'description' => 'If checked, frontend Topic views will be disabled.  You should uncheck this box if you plan on using Pages with shortcodes to display Topics and FAQs instead of this plugin\'s included Topic views.',
 					'type'        => 'checkbox'
 				)
 			);

--- a/includes/ucf-faq-posttype.php
+++ b/includes/ucf-faq-posttype.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'UCF_FAQ_PostType' ) ) {
 				'show_in_nav_menus'     => true,
 				'can_export'            => true,
 				'has_archive'           => true,
-				'rewrite'               => array( 'slug' => 'faq/question' ), //custom slug for single question pages
+				'rewrite'               => array( 'slug' => 'question' ), //custom slug for single question pages
 				'exclude_from_search'   => false,
 				'publicly_queryable'    => true,
 				'capability_type'       => 'post',

--- a/includes/ucf-faq-topic-tax.php
+++ b/includes/ucf-faq-topic-tax.php
@@ -49,10 +49,6 @@ if ( ! class_exists( 'UCF_FAQ_Topic' ) ) {
 				'rewrite'                    => array( 'slug' => 'faq' )
 			);
 
-			if ( UCF_FAQ_Config::get_option_or_default( UCF_FAQ_Config::$option_prefix . 'disable_frontend_topics' ) ) {
-				$args['public'] = false;
-			}
-
 			return $args;
 		}
 	}

--- a/includes/ucf-faq-topic-tax.php
+++ b/includes/ucf-faq-topic-tax.php
@@ -37,16 +37,23 @@ if ( ! class_exists( 'UCF_FAQ_Topic' ) ) {
 				'items_list_navigation'      => __( 'Topics list navigation', self::$text_domain ),
 			);
 		}
+
 		public static function args() {
-			return array(
+			$args = array(
 				'labels'                     => self::labels(),
 				'hierarchical'               => false,
 				'public'                     => true,
 				'show_ui'                    => true,
 				'show_admin_column'          => true,
-				'show_in_nav_menus'          => true,
 				'show_tagcloud'              => true,
+				'rewrite'                    => array( 'slug' => 'faq' )
 			);
+
+			if ( UCF_FAQ_Config::get_option_or_default( UCF_FAQ_Config::$option_prefix . 'disable_frontend_topics' ) ) {
+				$args['public'] = false;
+			}
+
+			return $args;
 		}
 	}
 }

--- a/shortcodes/ucf-faq-list-shortcode.php
+++ b/shortcodes/ucf-faq-list-shortcode.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'UCF_FAQ_Topic_List_Shortcode' ) ) {
 				'title'          => '',
 				'topic_element'  => 'h2',
 				'topic_class'    => 'h5',
-			), $atts, 'ucf-faq-list' );
+			), $atts, 'ucf-faq-topic-list' );
 
 			$topics = get_terms( 'topic', array(
 				'post_type' => array( 'faq' )

--- a/templates/single-faq.php
+++ b/templates/single-faq.php
@@ -2,6 +2,7 @@
 get_header();
 $atts['show'] = ( get_field( 'faq-topic-show-answers', get_queried_object() ) ) ?  " show" : "";
 $container_classes = " container my-5";
+$row_classes = " row";
 $title_classes = " mb-4";
 $answer_classes = " col-lg-8 mt-2 mb-4";
 $tags = array();
@@ -24,32 +25,34 @@ $related_faq_html = null;
 
 <article>
 	<div class="ucf-faq-list<?php UCF_FAQ_Config::add_athena_attr( $container_classes ); ?>">
-		<div class="ucf-faq-topic-answer<?php UCF_FAQ_Config::add_athena_attr( $answer_classes ); ?>">
-			<?php
-			echo apply_filters( 'the_content', $post->post_content );
+		<div class="ucf-faq-list-inner<?php UCF_FAQ_Config::add_athena_attr( $row_classes ); ?>">
+			<div class="ucf-faq-topic-answer<?php UCF_FAQ_Config::add_athena_attr( $answer_classes ); ?>">
+				<?php
+				echo apply_filters( 'the_content', $post->post_content );
 
-			foreach ( $related_posts as $post ) {
-				$related_faq_html .=  UCF_FAQ_Common::display_faq( $post, $atts );
-			}
+				foreach ( $related_posts as $post ) {
+					$related_faq_html .=  UCF_FAQ_Common::display_faq( $post, $atts );
+				}
 
-			if ( $related_faq_html ) :
-			?>
-				<h2 class="<?php UCF_FAQ_Config::add_athena_attr( 'h4 mt-5 mb-4' ); ?>">
-				<?php echo get_field( 'related-faq-title', $topic ); ?>
-				</h2>
-			<?php
-				echo $related_faq_html;
-			endif;
+				if ( $related_faq_html ) :
+				?>
+					<h2 class="<?php UCF_FAQ_Config::add_athena_attr( 'h4 mt-5 mb-4' ); ?>">
+					<?php echo get_field( 'related-faq-title', $topic ); ?>
+					</h2>
+				<?php
+					echo $related_faq_html;
+				endif;
 
-			if ( $cta_text && $cta_url ) :
-			?>
-				<a href="<?php echo $cta_url; ?>"
-					class="<?php UCF_FAQ_Config::add_athena_attr( 'btn btn-primary mt-4' ); ?>">
-					<?php echo $cta_text; ?>
-				</a>
-			<?php
-			endif;
-			?>
+				if ( $cta_text && $cta_url ) :
+				?>
+					<a href="<?php echo $cta_url; ?>"
+						class="<?php UCF_FAQ_Config::add_athena_attr( 'btn btn-primary mt-4' ); ?>">
+						<?php echo $cta_text; ?>
+					</a>
+				<?php
+				endif;
+				?>
+			</div>
 		</div>
 	</div>
 </article>

--- a/templates/taxonomy-topic.php
+++ b/templates/taxonomy-topic.php
@@ -1,87 +1,135 @@
-<?php
-get_header();
+<?php get_header(); ?>
 
-$tags = array();
-$faqs = array();
-$container_classes = " container mb-5";
-$atts['show'] = ( get_field( 'faq-topic-show-answers', get_queried_object() ) ) ?  " show" : "";
-$topic_description = term_description();
-$spotlight = false;
-if ( in_array( 'UCF-Spotlights-Plugin/ucf-spotlight.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-	$spotlight = get_field( 'faq-topic-spotlight', get_queried_object() );
-}
+<?php
+$topic = get_queried_object();
 ?>
 
-
 <article>
-	<div class="ucf-faq-topic-list<?php UCF_FAQ_Config::add_athena_attr( $container_classes ); ?>">
-		<?php
+	<?php
+	// Determine whether or not this template's default markup, or custom
+	// markup, should be displayed:
 
-		if ( ! empty( $topic_description ) ) :
-			$topic_description_classes = " col-lg-7 mb-4";
-		?>
-			<div class="<?php UCF_FAQ_Config::add_athena_attr( 'row' ); ?>">
-				<div class="ucf-faq-topic-description<?php UCF_FAQ_Config::add_athena_attr( $topic_description_classes ); ?>">
-					<?php UCF_FAQ_Config::add_athena_attr( $topic_description ); ?>
-		<?php
-		endif;
+	if ( get_field( 'faq-topic-view-type', $topic ) === 'custom' ) :
 
-		if ( have_posts() ) :
-				while ( have_posts() ) :
-					the_post();
+		// Display custom markup only
+		echo apply_filters( 'the_content', get_field( 'faq-topic-custom-content', $topic ) );
 
-					// Save FAQ and tag list to filter out of related FAQs section
-					array_push( $faqs, $post->ID );
+	else:
+		$tags              = array();
+		$faqs              = array();
+		$faq_atts          = array();
+		$faq_atts['show']  = ( get_field( 'faq-topic-show-answers', $topic ) ) ?  ' show' : '';
+		$related_posts     = array();
+		$related_faq_html  = '';
+		$related_faq_title = get_field( 'related-faq-title', $topic );
+		$cta_text          = get_field( 'faq-topic-footer-cta-text', $topic );
+		$cta_url           = get_field( 'faq-topic-footer-cta-url', $topic );
+		$spotlight         = false;
 
-					foreach ( wp_get_post_tags( $post->ID ) as $tag ) {
-						if ( ! in_array( $tag, $tags ) ) {
-							array_push( $tags, $tag->slug );
+		if ( in_array( 'UCF-Spotlights-Plugin/ucf-spotlight.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+			$spotlight = get_field( 'faq-topic-spotlight', $topic );
+		}
+
+		if ( substr( $cta_url, 0, 1 ) === '/' ) {
+			$cta_url = site_url(). $cta_url;
+		}
+	?>
+
+	<div class="ucf-faq-topic-list<?php UCF_FAQ_Config::add_athena_attr( ' container mb-5' ); ?>">
+		<div class="<?php UCF_FAQ_Config::add_athena_attr( 'row' ); ?>">
+			<div class="ucf-faq-topic-description<?php UCF_FAQ_Config::add_athena_attr( ' col-lg-7 mb-4' ); ?>">
+
+				<?php
+				// Display term description, if available
+				$topic_description = term_description();
+				if ( ! empty( $topic_description ) ) {
+					UCF_FAQ_Config::add_athena_attr( $topic_description );
+				}
+				?>
+
+				<?php if ( ! have_posts() ): ?>
+
+					<p>No results found.</p>
+
+				<?php else: ?>
+
+					<?php
+					// Display the main FAQ post loop:
+					while ( have_posts() ) : the_post();
+					?>
+						<?php
+						// Save FAQ and tag list to filter out of related FAQs section
+						array_push( $faqs, $post->ID );
+
+						foreach ( wp_get_post_tags( $post->ID ) as $tag ) {
+							if ( ! in_array( $tag, $tags ) ) {
+								array_push( $tags, $tag->slug );
+							}
 						}
-					}
+						?>
 
-					echo UCF_FAQ_Common::display_faq( $post, $atts );
-				endwhile;
+						<?php
+						// Display each individual FAQ
+						echo UCF_FAQ_Common::display_faq( $post, $faq_atts );
+						?>
 
+					<?php
+					// END main FAQ post loop
+					endwhile;
+					?>
+
+				<?php
+				// END have_posts()
+				endif;
+				?>
+
+
+				<?php
+				// Generate Related FAQs markup
 				$related_posts = UCF_FAQ_Common::get_related_faqs( $tags, $faqs );
-				$related_faq_html = null;
 
 				foreach ( $related_posts as $post ) {
-					$related_faq_html .=  UCF_FAQ_Common::display_faq( $post, $atts );
+					$related_faq_html .= UCF_FAQ_Common::display_faq( $post, $faq_atts );
 				}
+				?>
 
+				<?php
+				// Display Related FAQs
 				if ( $related_faq_html ) :
 				?>
+					<?php if ( $related_faq_title ): ?>
 					<h2 class="<?php UCF_FAQ_Config::add_athena_attr( 'h4 mt-5 mb-4' ); ?>">
-						<?php echo get_field( 'related-faq-title', get_queried_object() ); ?>
+						<?php echo wptexturize( $related_faq_title ); ?>
 					</h2>
+					<?php endif; ?>
+
+					<?php echo $related_faq_html; ?>
+				<?php endif; ?>
+
 				<?php
-					echo $related_faq_html;
-				endif;
-
-				if ( $cta_text = get_field( 'faq-topic-footer-cta-text', get_queried_object() ) ) :
-			?>
-					<a href="<?php echo site_url() . get_field( 'faq-topic-footer-cta-url', get_queried_object() ); ?>"
-						class="<?php UCF_FAQ_Config::add_athena_attr( 'btn btn-primary mt-4' ); ?>">
-						<?php echo $cta_text; ?>
-					</a>
-			<?php
-				endif;
-			?>
-				</div>
-
-				<?php if ( $spotlight ) : ?>
-					<div class="col-lg-4 offset-lg-1 mt-5 mt-md-2">
-						<?php echo do_shortcode( '[ucf-spotlight slug="' . $spotlight->post_name . '"]' ); ?>
-					</div>
+				// Display CTA Footer
+				if ( $cta_text && $cta_url ):
+				?>
+				<a href="<?php echo $cta_url; ?>" class="<?php UCF_FAQ_Config::add_athena_attr( 'btn btn-primary mt-4' ); ?>">
+					<?php echo wptexturize( $cta_text ); ?>
+				</a>
 				<?php endif; ?>
 
 			</div>
+
+
 			<?php
-		else: // have_posts() else
-			echo 'No results found.';
-		endif;
-		?>
+			// Display Sidebar Spotlight
+			if ( $spotlight ) :
+			?>
+			<div class="ucf-faq-topic-sidebar<?php UCF_FAQ_Config::add_athena_attr( ' col-lg-4 offset-lg-1 mt-5 mt-lg-2' ); ?>">
+				<?php echo do_shortcode( '[ucf-spotlight slug="' . $spotlight->post_name . '"]' ); ?>
+			</div>
+			<?php endif; ?>
+
+		</div>
 	</div>
+	<?php endif; ?>
 </article>
 
 <?php get_footer(); ?>

--- a/templates/taxonomy-topic.php
+++ b/templates/taxonomy-topic.php
@@ -35,7 +35,7 @@ $topic = get_queried_object();
 		}
 	?>
 
-	<div class="ucf-faq-topic-list<?php UCF_FAQ_Config::add_athena_attr( ' container mb-5' ); ?>">
+	<div class="ucf-faq-topic-list<?php UCF_FAQ_Config::add_athena_attr( ' container mt-4 mt-sm-5 mb-5' ); ?>">
 		<div class="<?php UCF_FAQ_Config::add_athena_attr( 'row' ); ?>">
 			<div class="ucf-faq-topic-description<?php UCF_FAQ_Config::add_athena_attr( ' col-lg-7 mb-4' ); ?>">
 


### PR DESCRIPTION
- Added URL rewrites: Topics now use the slug prefix `/faq/`, and FAQ posts use the prefix `/question/`.

  Note that pages with the slug `/faq/SUBPAGE-SLUG/` will now return 404s.  However, now that single Topics can display custom content (see below), this shouldn't be much of an issue.
- Added the ability to use arbitrary custom content in the single Topic template.  Using the provided template + Topic fields remains the default display option.
- Organized Topics fields a bit with tabs
- Added logic to single Topic view that only prefixes `site_url()` to the CTA URL value if it begins with a `/`

Other:
- Fixed last argument for `[ucf-faq-topic-list]` shortcode's `shortcode_atts()`
- Fixed issue in single Topic template that was causing the Spotlight column to collapse under the FAQs column
- Added missing `.row` div to single FAQ template