### PR TITLE
Removed row open/close based on column count in faq topic card layout

### DIFF
--- a/layouts/ucf-faq-topic-card.php
+++ b/layouts/ucf-faq-topic-card.php
@@ -55,12 +55,6 @@ if ( ! function_exists( 'ucf_faq_topic_list_display_card' ) ) {
 					</a>
 				</div>
 	<?php
-				if ( $key > 0 && ( $key + 1 ) % 3 === 0 ) :
-	?>
-					</div>
-					<div class="row">
-	<?php
-				endif;
 			endforeach;
 	?>
 			</div>


### PR DESCRIPTION
When updating the column widths for the FAQ Topic card layout earlier, I inadvertently broke the card layout at the -md breakpoint due to how rows are closed and open based on row count.

In this PR, I remove the row open/close logic--thanks to flexbox, we no longer need to start new rows like this; the cards within the rows will stack and flow as you'd expect them to.