### PR TITLE
Related FAQs on Topic Pages

### DIFF
--- a/common/ucf-faq-list-common.php
+++ b/common/ucf-faq-list-common.php
@@ -197,13 +197,40 @@ if ( ! class_exists( 'UCF_FAQ_Common' ) ) {
 			return $retval;
 		}
 
+		/**
+		 * Get related FAQs by topic excluding faqs already on the page.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 **/
+		public static function get_related_faqs_by_topic( $topics, $excluded_faqs ) {
+			if ( empty( $topics ) || ! is_array( $topics ) ) {
+				return array();
+			}
+
+			$retval = array();
+
+			foreach( $topics as $topic ) {
+				$related = get_field( 'related_faqs', "topic_{$topic->term_id}" );
+				$retval = array_merge( $retval, $related );
+			}
+
+			$retval = array_filter( $retval, function( $faq ) use( $excluded_faqs ) {
+				if ( in_array( $faq->ID, $excluded_faqs ) ) {
+					return false;
+				}
+
+				return true;
+			} );
+
+			return $retval;
+		}
 
 		/**
 		 * Get related FAQs by tag excluding faqs already on the page.
 		 * @author RJ Bruneel
 		 * @since 1.0.0
 		 **/
-		public static function get_related_faqs( $tags, $excluded_faqs ) {
+		public static function get_related_faqs_by_tag( $tags, $excluded_faqs ) {
 			if ( empty( $tags ) || ! is_array( $tags ) ) {
 				return array();
 			}

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,223 +1,33 @@
 [
     {
-        "key": "group_5b8598adb88f3",
+        "key": "group_5bb2728523045",
         "title": "Topic Fields",
         "fields": [
             {
-                "key": "field_5b9ace1a451fb",
-                "label": "Display Settings",
-                "name": "",
-                "type": "tab",
-                "instructions": "",
+                "key": "field_5bb2728dcd837",
+                "label": "Related FAQs",
+                "name": "related_faqs",
+                "type": "relationship",
+                "instructions": "The related FAQs that will be displayed as \"Related FAQs\" when using the [ucf-faq-list] and [ucf-faq-topic-list] shortcodes.",
                 "required": 0,
                 "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "placement": "top",
-                "endpoint": 0
-            },
-            {
-                "key": "field_5b85b5c65fe52",
-                "label": "Show FAQ Answers",
-                "name": "faq-topic-show-answers",
-                "type": "true_false",
-                "instructions": "If checked the FAQ answer will be visible on page load.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "",
-                "default_value": 0,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
-            },
-            {
-                "key": "field_5b8598c5aeaa9",
-                "label": "FAQ Topic Image",
-                "name": "faq-topic-image",
-                "type": "image",
-                "instructions": "An image displayed above the topic title on the card layout using the ucf-faq-topic-list shortcode.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "return_format": "array",
-                "preview_size": "thumbnail",
-                "library": "all",
-                "min_width": 300,
-                "min_height": 300,
-                "min_size": "",
-                "max_width": 500,
-                "max_height": 500,
-                "max_size": "",
-                "mime_types": "jpg, png"
-            },
-            {
-                "key": "field_5b9028cb19703",
-                "label": "Related FAQ Title",
-                "name": "related-faq-title",
-                "type": "text",
-                "instructions": "Title displayed above the related FAQ below topic FAQs.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "Related FAQs",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            },
-            {
-                "key": "field_5b90292019704",
-                "label": "FAQ Topic Footer CTA Text",
-                "name": "faq-topic-footer-cta-text",
-                "type": "text",
-                "instructions": "The text for the topic footer CTA link.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "View All FAQs",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            },
-            {
-                "key": "field_5b9029c019705",
-                "label": "FAQ Topic Footer CTA URL",
-                "name": "faq-topic-footer-cta-url",
-                "type": "text",
-                "instructions": "The url for the topic footer CTA link.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "\/faq\/",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
-                "maxlength": ""
-            },
-            {
-                "key": "field_5b9acdc1451f9",
-                "label": "Frontend Topic Contents",
-                "name": "",
-                "type": "tab",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "placement": "top",
-                "endpoint": 0
-            },
-            {
-                "key": "field_5b9ace2d451fc",
-                "label": "Single Topic View",
-                "name": "faq-topic-view-type",
-                "type": "select",
-                "instructions": "Select how this Topic's template should be displayed on the frontend.",
-                "required": 1,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "choices": {
-                    "default": "Default",
-                    "custom": "Custom Content"
-                },
-                "default_value": [
-                    "default"
-                ],
-                "allow_null": 0,
-                "multiple": 0,
-                "ui": 0,
-                "ajax": 0,
-                "return_format": "value",
-                "placeholder": ""
-            },
-            {
-                "key": "field_5b90050373b29",
-                "label": "Topic Spotlight",
-                "name": "faq-topic-spotlight",
-                "type": "post_object",
-                "instructions": "Select a Spotlight to be displayed on the topic list page.",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_5b9ace2d451fc",
-                            "operator": "==",
-                            "value": "default"
-                        }
-                    ]
-                ],
                 "wrapper": {
                     "width": "",
                     "class": "",
                     "id": ""
                 },
                 "post_type": [
-                    "ucf_spotlight"
+                    "faq"
                 ],
                 "taxonomy": [],
-                "allow_null": 0,
-                "multiple": 0,
-                "return_format": "object",
-                "ui": 1
-            },
-            {
-                "key": "field_5b9ad0b9451fd",
-                "label": "Topic Custom Content",
-                "name": "faq-topic-custom-content",
-                "type": "wysiwyg",
-                "instructions": "Custom content to use on the single Topic view, in lieu of the template provided by the UCF FAQ Plugin.  You will need to include FAQ lists yourself using the <code>[ucf-faq-list]<\/code> shortcode.",
-                "required": 0,
-                "conditional_logic": [
-                    [
-                        {
-                            "field": "field_5b9ace2d451fc",
-                            "operator": "==",
-                            "value": "custom"
-                        }
-                    ]
+                "filters": [
+                    "search",
+                    "taxonomy"
                 ],
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "default_value": "",
-                "tabs": "all",
-                "toolbar": "full",
-                "media_upload": 1,
-                "delay": 0
+                "elements": "",
+                "min": "",
+                "max": "",
+                "return_format": "object"
             }
         ],
         "location": [
@@ -229,7 +39,7 @@
                 }
             ]
         ],
-        "menu_order": -1,
+        "menu_order": 0,
         "position": "normal",
         "style": "default",
         "label_placement": "top",
@@ -239,15 +49,15 @@
         "description": ""
     },
     {
-        "key": "group_5b917a2fa04ba",
-        "title": "FAQ Question Fields",
+        "key": "group_5b8938cfc8824",
+        "title": "Two Column Template Fields",
         "fields": [
             {
-                "key": "field_5b917a3820356",
-                "label": "FAQ Question Sort Order",
-                "name": "faq_question_sort_order",
-                "type": "number",
-                "instructions": "",
+                "key": "field_5b8938ffe040b",
+                "label": "Lead Text",
+                "name": "page_lead_text",
+                "type": "wysiwyg",
+                "instructions": "Optional lead text to display immediately above the two column content on this page.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -256,20 +66,130 @@
                     "id": ""
                 },
                 "default_value": "",
-                "placeholder": "",
-                "prepend": "",
-                "append": "",
+                "tabs": "all",
+                "toolbar": "inline_text",
+                "media_upload": 0,
+                "delay": 0
+            },
+            {
+                "key": "field_5b8952e791e55",
+                "label": "Sidebar Contents",
+                "name": "page_sidebar_contents",
+                "type": "flexible_content",
+                "instructions": "Select one or more types of content to add to the sidebar on this page.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "layouts": {
+                    "5b89553e4c083": {
+                        "key": "5b89553e4c083",
+                        "name": "page_sidebar_layout_section",
+                        "label": "Section",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5b8955617325d",
+                                "label": "Select a Section",
+                                "name": "page_sidebar_section",
+                                "type": "post_object",
+                                "instructions": "Pick an existing Section to add to the sidebar.",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "ucf_section"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "object",
+                                "ui": 1
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    },
+                    "5b8955567325b": {
+                        "key": "5b8955567325b",
+                        "name": "page_sidebar_layout_spotlight",
+                        "label": "Spotlight",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5b8955ff7325e",
+                                "label": "Select a Spotlight",
+                                "name": "page_sidebar_spotlight",
+                                "type": "post_object",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "post_type": [
+                                    "ucf_spotlight"
+                                ],
+                                "taxonomy": [],
+                                "allow_null": 0,
+                                "multiple": 0,
+                                "return_format": "object",
+                                "ui": 1
+                            }
+                        ],
+                        "min": "",
+                        "max": "1"
+                    },
+                    "5b89555a7325c": {
+                        "key": "5b89555a7325c",
+                        "name": "page_sidebar_layout_custom",
+                        "label": "Custom Content",
+                        "display": "block",
+                        "sub_fields": [
+                            {
+                                "key": "field_5b8956187325f",
+                                "label": "Custom Content",
+                                "name": "page_sidebar_custom",
+                                "type": "wysiwyg",
+                                "instructions": "",
+                                "required": 1,
+                                "conditional_logic": 0,
+                                "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                },
+                                "default_value": "",
+                                "tabs": "all",
+                                "toolbar": "full",
+                                "media_upload": 1,
+                                "delay": 0
+                            }
+                        ],
+                        "min": "",
+                        "max": ""
+                    }
+                },
+                "button_label": "Add Sidebar Content",
                 "min": "",
-                "max": "",
-                "step": ""
+                "max": ""
             }
         ],
         "location": [
             [
                 {
-                    "param": "post_type",
+                    "param": "page_template",
                     "operator": "==",
-                    "value": "faq"
+                    "value": "template-twocol.php"
                 }
             ]
         ],

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,14 +1,92 @@
 [
     {
-        "key": "group_5bb2728523045",
+        "key": "group_5b8598adb88f3",
         "title": "Topic Fields",
         "fields": [
             {
-                "key": "field_5bb2728dcd837",
+                "key": "field_5b9ace1a451fb",
+                "label": "Display Settings",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5b85b5c65fe52",
+                "label": "Show FAQ Answers",
+                "name": "faq-topic-show-answers",
+                "type": "true_false",
+                "instructions": "If checked the FAQ answer will be visible on page load.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "",
+                "default_value": 0,
+                "ui": 0,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5b8598c5aeaa9",
+                "label": "FAQ Topic Image",
+                "name": "faq-topic-image",
+                "type": "image",
+                "instructions": "An image displayed above the topic title on the card layout using the ucf-faq-topic-list shortcode.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "return_format": "array",
+                "preview_size": "thumbnail",
+                "library": "all",
+                "min_width": 300,
+                "min_height": 300,
+                "min_size": "",
+                "max_width": 500,
+                "max_height": 500,
+                "max_size": "",
+                "mime_types": "jpg, png"
+            },
+            {
+                "key": "field_5b9028cb19703",
+                "label": "Related FAQ Title",
+                "name": "related-faq-title",
+                "type": "text",
+                "instructions": "Title displayed above the related FAQ below topic FAQs.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "Related FAQs",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5bb370e9c4c2f",
                 "label": "Related FAQs",
                 "name": "related_faqs",
                 "type": "relationship",
-                "instructions": "The related FAQs that will be displayed as \"Related FAQs\" when using the [ucf-faq-list] and [ucf-faq-topic-list] shortcodes.",
+                "instructions": "The related FAQs that will be displayed as \\\"Related FAQs\\\" when using the [ucf-faq-list] and [ucf-faq-topic-list] shortcodes.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -28,6 +106,144 @@
                 "min": "",
                 "max": "",
                 "return_format": "object"
+            },
+            {
+                "key": "field_5b90292019704",
+                "label": "FAQ Topic Footer CTA Text",
+                "name": "faq-topic-footer-cta-text",
+                "type": "text",
+                "instructions": "The text for the topic footer CTA link.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "View All FAQs",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5b9029c019705",
+                "label": "FAQ Topic Footer CTA URL",
+                "name": "faq-topic-footer-cta-url",
+                "type": "text",
+                "instructions": "The url for the topic footer CTA link.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "\/faq\/",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5b9acdc1451f9",
+                "label": "Frontend Topic Contents",
+                "name": "",
+                "type": "tab",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "placement": "top",
+                "endpoint": 0
+            },
+            {
+                "key": "field_5b9ace2d451fc",
+                "label": "Single Topic View",
+                "name": "faq-topic-view-type",
+                "type": "select",
+                "instructions": "Select how this Topic's template should be displayed on the frontend.",
+                "required": 1,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "choices": {
+                    "default": "Default",
+                    "custom": "Custom Content"
+                },
+                "default_value": [
+                    "default"
+                ],
+                "allow_null": 0,
+                "multiple": 0,
+                "ui": 0,
+                "ajax": 0,
+                "return_format": "value",
+                "placeholder": ""
+            },
+            {
+                "key": "field_5b90050373b29",
+                "label": "Topic Spotlight",
+                "name": "faq-topic-spotlight",
+                "type": "post_object",
+                "instructions": "Select a Spotlight to be displayed on the topic list page.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5b9ace2d451fc",
+                            "operator": "==",
+                            "value": "default"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "ucf_spotlight"
+                ],
+                "taxonomy": [],
+                "allow_null": 0,
+                "multiple": 0,
+                "return_format": "object",
+                "ui": 1
+            },
+            {
+                "key": "field_5b9ad0b9451fd",
+                "label": "Topic Custom Content",
+                "name": "faq-topic-custom-content",
+                "type": "wysiwyg",
+                "instructions": "Custom content to use on the single Topic view, in lieu of the template provided by the UCF FAQ Plugin.  You will need to include FAQ lists yourself using the <code>[ucf-faq-list]<\/code> shortcode.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5b9ace2d451fc",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "tabs": "all",
+                "toolbar": "full",
+                "media_upload": 1,
+                "delay": 0
             }
         ],
         "location": [
@@ -39,7 +255,7 @@
                 }
             ]
         ],
-        "menu_order": 0,
+        "menu_order": -1,
         "position": "normal",
         "style": "default",
         "label_placement": "top",
@@ -49,15 +265,15 @@
         "description": ""
     },
     {
-        "key": "group_5b8938cfc8824",
-        "title": "Two Column Template Fields",
+        "key": "group_5b917a2fa04ba",
+        "title": "FAQ Question Fields",
         "fields": [
             {
-                "key": "field_5b8938ffe040b",
-                "label": "Lead Text",
-                "name": "page_lead_text",
-                "type": "wysiwyg",
-                "instructions": "Optional lead text to display immediately above the two column content on this page.",
+                "key": "field_5b917a3820356",
+                "label": "FAQ Question Sort Order",
+                "name": "faq_question_sort_order",
+                "type": "number",
+                "instructions": "",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -66,130 +282,20 @@
                     "id": ""
                 },
                 "default_value": "",
-                "tabs": "all",
-                "toolbar": "inline_text",
-                "media_upload": 0,
-                "delay": 0
-            },
-            {
-                "key": "field_5b8952e791e55",
-                "label": "Sidebar Contents",
-                "name": "page_sidebar_contents",
-                "type": "flexible_content",
-                "instructions": "Select one or more types of content to add to the sidebar on this page.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "layouts": {
-                    "5b89553e4c083": {
-                        "key": "5b89553e4c083",
-                        "name": "page_sidebar_layout_section",
-                        "label": "Section",
-                        "display": "block",
-                        "sub_fields": [
-                            {
-                                "key": "field_5b8955617325d",
-                                "label": "Select a Section",
-                                "name": "page_sidebar_section",
-                                "type": "post_object",
-                                "instructions": "Pick an existing Section to add to the sidebar.",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "post_type": [
-                                    "ucf_section"
-                                ],
-                                "taxonomy": [],
-                                "allow_null": 0,
-                                "multiple": 0,
-                                "return_format": "object",
-                                "ui": 1
-                            }
-                        ],
-                        "min": "",
-                        "max": ""
-                    },
-                    "5b8955567325b": {
-                        "key": "5b8955567325b",
-                        "name": "page_sidebar_layout_spotlight",
-                        "label": "Spotlight",
-                        "display": "block",
-                        "sub_fields": [
-                            {
-                                "key": "field_5b8955ff7325e",
-                                "label": "Select a Spotlight",
-                                "name": "page_sidebar_spotlight",
-                                "type": "post_object",
-                                "instructions": "",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "post_type": [
-                                    "ucf_spotlight"
-                                ],
-                                "taxonomy": [],
-                                "allow_null": 0,
-                                "multiple": 0,
-                                "return_format": "object",
-                                "ui": 1
-                            }
-                        ],
-                        "min": "",
-                        "max": "1"
-                    },
-                    "5b89555a7325c": {
-                        "key": "5b89555a7325c",
-                        "name": "page_sidebar_layout_custom",
-                        "label": "Custom Content",
-                        "display": "block",
-                        "sub_fields": [
-                            {
-                                "key": "field_5b8956187325f",
-                                "label": "Custom Content",
-                                "name": "page_sidebar_custom",
-                                "type": "wysiwyg",
-                                "instructions": "",
-                                "required": 1,
-                                "conditional_logic": 0,
-                                "wrapper": {
-                                    "width": "",
-                                    "class": "",
-                                    "id": ""
-                                },
-                                "default_value": "",
-                                "tabs": "all",
-                                "toolbar": "full",
-                                "media_upload": 1,
-                                "delay": 0
-                            }
-                        ],
-                        "min": "",
-                        "max": ""
-                    }
-                },
-                "button_label": "Add Sidebar Content",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
                 "min": "",
-                "max": ""
+                "max": "",
+                "step": ""
             }
         ],
         "location": [
             [
                 {
-                    "param": "page_template",
+                    "param": "post_type",
                     "operator": "==",
-                    "value": "template-twocol.php"
+                    "value": "faq"
                 }
             ]
         ],

--- a/shortcodes/ucf-faq-list-shortcode.php
+++ b/shortcodes/ucf-faq-list-shortcode.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'UCF_FAQ_List_Shortcode' ) ) {
 				$related_exclude = array_map( function( $value ) {
 					return $value->ID;
 				}, $posts );
-				$related_posts = UCF_FAQ_Common::get_related_faqs( $related_tags, $related_exclude );
+				$related_posts = UCF_FAQ_Common::get_related_faqs_by_tag( $related_tags, $related_exclude );
 				$related_faq_markup = UCF_FAQ_Common::display_related_faqs( $related_posts, 'Related FAQs', $atts );
 			}
 

--- a/templates/single-faq.php
+++ b/templates/single-faq.php
@@ -19,7 +19,7 @@ $cta_text = get_field( 'faq-topic-footer-cta-text', $topic );
 $cta_url = site_url() . get_field( 'faq-topic-footer-cta-url', $topic );
 
 $tags = wp_get_post_tags( $post->ID, array( 'fields' => 'slugs' ) );
-$related_posts = UCF_FAQ_Common::get_related_faqs( $tags, array( $post->ID ) );
+$related_posts = UCF_FAQ_Common::get_related_faqs_by_tag( $tags, array( $post->ID ) );
 ?>
 
 <article>

--- a/templates/taxonomy-topic.php
+++ b/templates/taxonomy-topic.php
@@ -52,19 +52,8 @@ $topic = get_queried_object();
 					<?php
 					// Display the main FAQ post loop:
 					while ( have_posts() ) : the_post();
-					?>
-						<?php
-						// Save FAQ and tag list to filter out of related FAQs section
-						array_push( $faqs, $post->ID );
+						$faqs[] = $post->ID;
 
-						foreach ( wp_get_post_tags( $post->ID ) as $tag ) {
-							if ( ! in_array( $tag, $tags ) ) {
-								array_push( $tags, $tag->slug );
-							}
-						}
-						?>
-
-						<?php
 						// Display each individual FAQ
 						$unique_id = wp_rand();
 						echo UCF_FAQ_Common::display_faq( $post, $faq_atts, $unique_id );
@@ -83,7 +72,7 @@ $topic = get_queried_object();
 
 				<?php
 				// Generate Related FAQs markup
-				$related_posts = UCF_FAQ_Common::get_related_faqs( $tags, $faqs );
+				$related_posts = UCF_FAQ_Common::get_related_faqs_by_topic( array( $topic ), $faqs );
 				echo UCF_FAQ_Common::display_related_faqs( $related_posts, $related_faq_title, $faq_atts );
 
 				// Display CTA Footer


### PR DESCRIPTION
Enhancements:
* Added a `related_faqs` field to topic taxonomy terms and added logic for displaying them.
* Updated `get_related_faqs` to be two functions, one for retrieving by topic and one by tag.