### PR TITLE
FAQ sort order fix

### DIFF
--- a/common/ucf-faq-list-common.php
+++ b/common/ucf-faq-list-common.php
@@ -243,8 +243,8 @@ if ( ! class_exists( 'UCF_FAQ_Common' ) ) {
 				'posts_per_page' => -1,
 				'post__not_in'   => $excluded_faqs,
 				'orderby'        => array(
-					'meta_value' => 'ASC',
-					'title'      => 'ASC'
+					'meta_value_num' => 'ASC',
+					'title'          => 'ASC'
 				),
 				'meta_query'     => array(
 					'relation' => 'OR',

--- a/shortcodes/ucf-faq-list-shortcode.php
+++ b/shortcodes/ucf-faq-list-shortcode.php
@@ -47,8 +47,8 @@ if ( ! class_exists( 'UCF_FAQ_List_Shortcode' ) ) {
 
 				// Order by meta_value first, then title
 				$args['orderby'] = array(
-					'meta_value' => 'ASC',
-					'title'      => 'ASC'
+					'meta_value_num' => 'ASC',
+					'title'          => 'ASC'
 				);
 
 				$args['meta_query'] = array(

--- a/templates/templates.php
+++ b/templates/templates.php
@@ -75,8 +75,8 @@ function ucf_faq_sort_order( $query ) {
 		)
 	) {
 		$orderby = array(
-			'meta_value' => 'ASC',
-			'title'      => 'ASC'
+			'meta_value_num' => 'ASC',
+			'title'          => 'ASC'
 		);
 
 		$query->set( 'orderby', $orderby );


### PR DESCRIPTION
Set queries for FAQs using sorting by `faq_question_sort_order` to use `meta_value_num` instead of `meta_value` so that results are sorted numerically as expected.