### PR TITLE
Added Default Sort Order Option

### DIFF
--- a/common/ucf-faq-list-common.php
+++ b/common/ucf-faq-list-common.php
@@ -1,19 +1,4 @@
 <?php
-if ( ! function_exists( 'ucf_faq_enqueue_assets' ) ) {
-	function ucf_faq_enqueue_assets() {
-		// CSS
-		$include_athena_classes = UCF_FAQ_Config::get_option_or_default( 'include_athena_classes' );
-		$css_deps = apply_filters( 'ucf_faq_style_deps', array() );
-		if ( $include_athena_classes ) {
-			$plugin_data   = get_plugin_data( UCF_FAQ__PLUGIN_FILE, false, false );
-			$version       = $plugin_data['Version'];
-			wp_enqueue_style( 'ucf_faq_css', plugins_url( 'static/css/ucf-faq.min.css', UCF_FAQ__PLUGIN_FILE ), $css_deps, $version, 'screen' );
-		}
-	}
-	add_action( 'wp_enqueue_scripts', 'ucf_faq_enqueue_assets' );
-}
-
-
 /**
  * Defines hooks for displaying a list of FAQs.
  * @author RJ Bruneel
@@ -286,6 +271,38 @@ if ( ! class_exists( 'UCF_FAQ_Common' ) ) {
 			} else {
 			  return 1;
 			}
-		  }
+		}
+
+		public static function enqueue_assets() {
+			// CSS
+			$include_athena_classes = UCF_FAQ_Config::get_option_or_default( 'include_athena_classes' );
+			$css_deps = apply_filters( 'ucf_faq_style_deps', array() );
+			if ( $include_athena_classes ) {
+				$plugin_data   = get_plugin_data( UCF_FAQ__PLUGIN_FILE, false, false );
+				$version       = $plugin_data['Version'];
+				wp_enqueue_style( 'ucf_faq_css', plugins_url( 'static/css/ucf-faq.min.css', UCF_FAQ__PLUGIN_FILE ), $css_deps, $version, 'screen' );
+			}
+		}
+
+		public static function set_default_sort_order() {
+			// Can't get a local field, return.
+			if ( ! function_exists( 'acf_get_local_field' ) ) return;
+
+			$sort_order_key = 'field_5b917a3820356';
+			$sort_order_field = acf_get_local_field( $sort_order_key );
+			if ( ! $sort_order_field ) return;
+
+			// Modify existing sort order field settings to force
+			// a default value.
+			$sort_order_field['default_value'] = 99999;
+			acf_remove_local_field( $sort_order_key );
+			acf_add_local_field( $sort_order_field );
+		}
+	}
+
+	add_action( 'wp_enqueue_scripts', array( 'UCF_FAQ_Common', 'enqueue_assets' ) );
+
+	if ( UCF_FAQ_Config::get_option_or_default( 'default_sort_order' ) ) {
+		add_action( 'acf/init', array( 'UCF_FAQ_Common', 'set_default_sort_order' ) );
 	}
 }

--- a/common/ucf-faq-list-common.php
+++ b/common/ucf-faq-list-common.php
@@ -283,26 +283,7 @@ if ( ! class_exists( 'UCF_FAQ_Common' ) ) {
 				wp_enqueue_style( 'ucf_faq_css', plugins_url( 'static/css/ucf-faq.min.css', UCF_FAQ__PLUGIN_FILE ), $css_deps, $version, 'screen' );
 			}
 		}
-
-		public static function set_default_sort_order() {
-			// Can't get a local field, return.
-			if ( ! function_exists( 'acf_get_local_field' ) ) return;
-
-			$sort_order_key = 'field_5b917a3820356';
-			$sort_order_field = acf_get_local_field( $sort_order_key );
-			if ( ! $sort_order_field ) return;
-
-			// Modify existing sort order field settings to force
-			// a default value.
-			$sort_order_field['default_value'] = 99999;
-			acf_remove_local_field( $sort_order_key );
-			acf_add_local_field( $sort_order_field );
-		}
 	}
 
 	add_action( 'wp_enqueue_scripts', array( 'UCF_FAQ_Common', 'enqueue_assets' ) );
-
-	if ( UCF_FAQ_Config::get_option_or_default( 'default_sort_order' ) ) {
-		add_action( 'acf/init', array( 'UCF_FAQ_Common', 'set_default_sort_order' ) );
-	}
 }

--- a/includes/ucf-faq-config.php
+++ b/includes/ucf-faq-config.php
@@ -7,7 +7,8 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 		public static $option_prefix = 'ucf_faq_',
 		$option_defaults = array(
 			'include_athena_classes'  => true,
-			'disable_faq_archive'     => false
+			'disable_faq_archive'     => false,
+			'default_sort_order'      => false
 		);
 
 
@@ -21,6 +22,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			$defaults = self::$option_defaults; // don't use self::get_option_defaults() here (default options haven't been set yet)
 			add_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] );
 			add_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] );
+			add_option( self::$option_prefix . 'default_sort_order', $defaults['default_sort_order'] );
 		}
 
 
@@ -33,6 +35,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 		public static function delete_options() {
 			delete_option( self::$option_prefix . 'include_athena_classes' );
 			delete_option( self::$option_prefix . 'disable_faq_archive' );
+			delete_option( self::$option_prefix . 'default_sort_order' );
 		}
 
 
@@ -49,6 +52,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			$configurable_defaults = array(
 				'include_athena_classes' => get_option( self::$option_prefix . 'include_athena_classes', $defaults['include_athena_classes'] ),
 				'disable_faq_archive'    => get_option( self::$option_prefix . 'disable_faq_archive', $defaults['disable_faq_archive'] ),
+				'default_sort_order'     => get_option( self::$option_prefix . 'default_sort_order', $defaults['default_sort_order'] ),
 			);
 
 			// Force configurable options to override $defaults, even if they are empty:
@@ -69,6 +73,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				switch ( $key ) {
 					case 'include_athena_classes':
 					case 'disable_faq_archive':
+					case 'default_sort_order':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
 						break;
 					default:
@@ -126,6 +131,7 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 			// Register settings
 			register_setting( 'ucf_faq', self::$option_prefix . 'include_athena_classes' );
 			register_setting( 'ucf_faq', self::$option_prefix . 'disable_faq_archive' );
+			register_setting( 'ucf_faq', self::$option_prefix . 'default_sort_order' );
 
 			// Register setting sections
 			add_settings_section(
@@ -158,6 +164,19 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 				array(  // extra arguments to pass to the callback function
 					'label_for'   => self::$option_prefix . 'disable_faq_archive',
 					'description' => 'If checked the FAQ Archive will be disabled.',
+					'type'        => 'checkbox'
+				)
+			);
+
+			add_settings_field(
+				self::$option_prefix . 'default_sort_order',
+				'Set Default Value',
+				array( 'UCF_FAQ_CONFIG', 'display_settings_field' ),
+				'ucf_faq',
+				'ucf_faq_section_general',
+				array(
+					'label_for'   => self::$option_prefix . 'default_sort_order',
+					'description' => 'If checked a default value will be set on each FAQ sort order.',
 					'type'        => 'checkbox'
 				)
 			);

--- a/includes/ucf-faq-config.php
+++ b/includes/ucf-faq-config.php
@@ -170,13 +170,13 @@ if ( ! class_exists( 'UCF_FAQ_Config' ) ) {
 
 			add_settings_field(
 				self::$option_prefix . 'default_sort_order',
-				'Set Default Value',
+				'Set high default FAQ sort order',
 				array( 'UCF_FAQ_CONFIG', 'display_settings_field' ),
 				'ucf_faq',
 				'ucf_faq_section_general',
 				array(
 					'label_for'   => self::$option_prefix . 'default_sort_order',
-					'description' => 'If checked a default value will be set on each FAQ sort order.',
+					'description' => 'If checked, new FAQs will have a default sort order value that pushes them to the end of sorted FAQ lists. When left unchecked, new FAQs will not have a default sort order value set, and will be shown at the beginning of sorted FAQ lists.',
 					'type'        => 'checkbox'
 				)
 			);

--- a/includes/ucf-faq-posttype.php
+++ b/includes/ucf-faq-posttype.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'UCF_FAQ_PostType' ) ) {
 			 * @author Jim Barnes
 			 * @since 1.1.0
 			 */
-			$fields[] = array(
+			$sort_order = array(
 				'key' => 'field_5b917a3820356',
 				'label' => 'FAQ Question Sort Order',
 				'name' => 'faq_question_sort_order',
@@ -143,6 +143,12 @@ if ( ! class_exists( 'UCF_FAQ_PostType' ) ) {
 				'instructions' => '',
 				'required' => 0
 			);
+
+			if ( UCF_FAQ_Config::get_option_or_default( 'default_sort_order' ) ) {
+				$sort_order['default_value'] = 99999;
+			}
+
+			$fields[] = $sort_order;
 
 			/**
 			 * Define field group


### PR DESCRIPTION
Enhancements:
* Added the `default_sort_order` option. When checked, a default sort order of 99,999 will be set on all new FAQs.
* Moved the enqueue assets function inside on of the common classes for consistency.