### PR TITLE
Fixed early usage of conditional query tags and `get_query_var()`

### DIFF
--- a/templates/templates.php
+++ b/templates/templates.php
@@ -69,9 +69,9 @@ function ucf_faq_sort_order( $query ) {
 	if (
 		! is_admin()
 		&& (
-			is_tax( 'topic' )
-			|| ( $query->get( 'post_type' ) === 'faq' && is_archive() )
-			|| is_post_type_archive( 'faq' )
+			$query->is_tax( 'topic' )
+			|| ( $query->get( 'post_type' ) === 'faq' && $query->is_archive() )
+			|| $query->is_post_type_archive( 'faq' )
 		)
 	) {
 		$orderby = array(

--- a/templates/templates.php
+++ b/templates/templates.php
@@ -70,7 +70,7 @@ function ucf_faq_sort_order( $query ) {
 		! is_admin()
 		&& (
 			is_tax( 'topic' )
-			|| ( get_query_var( 'post_type' ) === 'faq' && is_archive() )
+			|| ( $query->get( 'post_type' ) === 'faq' && is_archive() )
 			|| is_post_type_archive( 'faq' )
 		)
 	) {


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-FAQ-CPT.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-FAQ-CPT/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updated `ucf_faq_sort_order()` to call `WP_Query` methods directly off of the passed-in `$query` object from `pre_get_posts`, instead of calling conditional query tags like `is_tax()` directly.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix resolves some "you're doing it wrong" notices, and also fixes a bizarre critical error we've been running into in a new plugin that utilizes ACF.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
